### PR TITLE
feat(frontend): add vite react setup

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fast API Codex</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add index.html mounting root and script
- add React entrypoint rendering App
- configure Vite with React plugin

## Testing
- `npm install` *(fails: 403 Forbidden for @ionic/react)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca5fe1910832d8c85cea2deb01ecc