### PR TITLE
Use built-in list for relationship annotations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -19,7 +19,7 @@ class User(SQLModel, table=True):
     notify_whatsapp: bool = Field(default=False)
     notify_telegram: bool = Field(default=False)
 
-    liked_offers: List["LikedOffer"] = Relationship(back_populates="user")
+    liked_offers: list["LikedOffer"] = Relationship(back_populates="user")
 
 
 class Offer(SQLModel, table=True):
@@ -30,7 +30,7 @@ class Offer(SQLModel, table=True):
     promo_code: Optional[str] = None
     expires_at: datetime
 
-    liked_by: List["LikedOffer"] = Relationship(back_populates="offer")
+    liked_by: list["LikedOffer"] = Relationship(back_populates="offer")
 
 
 class LikedOffer(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- use built-in `list` for relationship fields in models

## Testing
- `uvicorn app.main:app --host 127.0.0.1 --port 8000` *(fails: missing dependencies)*
- `pip install fastapi sqlmodel`
- `pip install passlib[bcrypt]`
- `pip install email-validator`
- `uvicorn app.main:app --host 127.0.0.1 --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_68acb5202db0832db7fe5b40332dbed8