### PR TITLE
Remove string annotations for liked offer relations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy.orm import Mapped
 from sqlmodel import SQLModel, Field, Relationship
 
 
@@ -19,7 +20,7 @@ class User(SQLModel, table=True):
     notify_whatsapp: bool = Field(default=False)
     notify_telegram: bool = Field(default=False)
 
-    liked_offers: list["LikedOffer"] = Relationship(back_populates="user")
+    liked_offers: Mapped[list[LikedOffer]] = Relationship(back_populates="user")
 
 
 class Offer(SQLModel, table=True):
@@ -30,7 +31,7 @@ class Offer(SQLModel, table=True):
     promo_code: Optional[str] = None
     expires_at: datetime
 
-    liked_by: list["LikedOffer"] = Relationship(back_populates="offer")
+    liked_by: Mapped[list[LikedOffer]] = Relationship(back_populates="offer")
 
 
 class LikedOffer(SQLModel, table=True):
@@ -39,5 +40,5 @@ class LikedOffer(SQLModel, table=True):
     offer_id: int = Field(foreign_key="offer.id")
     liked_at: datetime = Field(default_factory=datetime.utcnow)
 
-    user: User = Relationship(back_populates="liked_offers")
-    offer: Offer = Relationship(back_populates="liked_by")
+    user: Mapped[User] = Relationship(back_populates="liked_offers")
+    offer: Mapped[Offer] = Relationship(back_populates="liked_by")


### PR DESCRIPTION
## Summary
- use SQLAlchemy `Mapped` typing for `liked_offers` and `liked_by` relationships to avoid generic class errors

## Testing
- `pytest`
- `timeout 5 uvicorn app.main:app --reload` *(fails: ModuleNotFoundError: No module named 'passlib')*


------
https://chatgpt.com/codex/tasks/task_e_68acb7645190832da4190a51d802ccfc